### PR TITLE
Revert to old index implementation

### DIFF
--- a/.changeset/evil-pianos-hear.md
+++ b/.changeset/evil-pianos-hear.md
@@ -2,4 +2,4 @@
 '@electric-sql/d2mini': patch
 ---
 
-Modify index implementation to keep a map of consolidated values and their multiplicities. This improves efficiency to get a value's multiplicity since it's already precomputed.
+Modify index implementation to keep a map of consolidated values and their multiplicities. This improves efficiency to get a value's multiplicity since it's already precomputed. Also modify reduce operator to emit a single diff instead of 2 diffs (1 that is -oldMultiplicity and 1 that is +newMultiplicity).

--- a/.changeset/evil-pianos-hear.md
+++ b/.changeset/evil-pianos-hear.md
@@ -1,0 +1,5 @@
+---
+'@electric-sql/d2mini': patch
+---
+
+Modify index implementation to keep a map of consolidated values and their multiplicities. This improves efficiency to get a value's multiplicity since it's already precomputed.

--- a/packages/d2mini/src/indexes.ts
+++ b/packages/d2mini/src/indexes.ts
@@ -7,24 +7,32 @@ import { DefaultMap, hash } from './utils.js'
  * exploit the key-value structure of the data to run efficiently.
  */
 export class Index<K, V> {
-  #inner: DefaultMap<K, [V, number][]>
-  #changedKeys: Set<K>
+  #inner: DefaultMap<K, DefaultMap<string, [V, number]>>
 
   constructor() {
-    this.#inner = new DefaultMap<K, [V, number][]>(() => [])
-    this.#changedKeys = new Set<K>()
+    this.#inner = new DefaultMap<K, DefaultMap<string, [V, number]>>(
+      () =>
+        new DefaultMap<string, [V, number]>(() => [undefined as any as V, 0]),
+    )
+    // #inner is as map of:
+    // {
+    //   [key]: {
+    //     [hash(value)]: [value, multiplicity]
+    //   }
+    // }
   }
 
   toString(indent = false): string {
     return `Index(${JSON.stringify(
-      [...this.#inner],
+      [...this.#inner].map(([k, valueMap]) => [k, [...valueMap]]),
       undefined,
       indent ? '  ' : undefined,
     )})`
   }
 
   get(key: K): [V, number][] {
-    return this.#inner.get(key)
+    const valueMap = this.#inner.get(key)
+    return [...valueMap.values()]
   }
 
   entries() {
@@ -36,78 +44,44 @@ export class Index<K, V> {
   }
 
   has(key: K): boolean {
-    return this.#inner.has(key) && this.#inner.get(key).length > 0
+    return this.#inner.has(key)
   }
 
   get size(): number {
-    let count = 0
-    for (const [, values] of this.#inner.entries()) {
-      if (values.length > 0) {
-        count++
-      }
-    }
-    return count
+    return this.#inner.size
   }
 
   addValue(key: K, value: [V, number]): void {
-    const values = this.#inner.get(key)
-    values.push(value)
-    this.#changedKeys.add(key)
+    const [val, multiplicity] = value
+    const valueMap = this.#inner.get(key)
+    const valueHash = hash(val)
+    const [, existingMultiplicity] = valueMap.get(valueHash)
+    const newMultiplicity = existingMultiplicity + multiplicity
+    if (multiplicity !== 0) {
+      if (newMultiplicity === 0) {
+        valueMap.delete(valueHash)
+      } else {
+        valueMap.set(valueHash, [val, newMultiplicity])
+      }
+    }
   }
 
   append(other: Index<K, V>): void {
-    for (const [key, otherValues] of other.entries()) {
-      const thisValues = this.#inner.get(key)
-      for (const value of otherValues) {
-        thisValues.push(value)
-      }
-      this.#changedKeys.add(key)
-    }
-  }
-
-  compact(keys: K[] = []): void {
-    // If no keys specified, use the changed keys
-    const keysToProcess = keys.length === 0 ? [...this.#changedKeys] : keys
-
-    for (const key of keysToProcess) {
-      if (!this.#inner.has(key)) continue
-
-      const values = this.#inner.get(key)
-      const consolidated = this.consolidateValues(values)
-
-      // Remove the key entirely and re-add only if there are non-zero values
-      this.#inner.delete(key)
-      if (consolidated.length > 0) {
-        this.#inner.get(key).push(...consolidated)
+    for (const [key, otherValueMap] of other.entries()) {
+      const thisValueMap = this.#inner.get(key)
+      for (const [
+        valueHash,
+        [value, multiplicity],
+      ] of otherValueMap.entries()) {
+        const [, existingMultiplicity] = thisValueMap.get(valueHash)
+        const newMultiplicity = existingMultiplicity + multiplicity
+        if (newMultiplicity === 0) {
+          thisValueMap.delete(valueHash)
+        } else {
+          thisValueMap.set(valueHash, [value, newMultiplicity])
+        }
       }
     }
-
-    // Clear the changed keys after compaction
-    if (keys.length === 0) {
-      this.#changedKeys.clear()
-    } else {
-      // Only remove the keys that were explicitly compacted
-      for (const key of keys) {
-        this.#changedKeys.delete(key)
-      }
-    }
-  }
-
-  private consolidateValues(values: [V, number][]): [V, number][] {
-    const consolidated = new Map<string, { value: V; multiplicity: number }>()
-
-    for (const [value, multiplicity] of values) {
-      const valueHash = hash(value)
-      if (consolidated.has(valueHash)) {
-        consolidated.get(valueHash)!.multiplicity += multiplicity
-      } else {
-        consolidated.set(valueHash, { value, multiplicity })
-      }
-    }
-
-    return [...consolidated.values()]
-      .filter(({ multiplicity }) => multiplicity !== 0)
-      .map(({ value, multiplicity }) => [value, multiplicity])
   }
 
   join<V2>(other: Index<K, V2>): MultiSet<[K, [V, V2]]> {
@@ -116,11 +90,11 @@ export class Index<K, V> {
     // We want to iterate over the smaller of the two indexes to reduce the
     // number of operations we need to do.
     if (this.size <= other.size) {
-      for (const [key, values1] of this.entries()) {
+      for (const [key, valueMap] of this.entries()) {
         if (!other.has(key)) continue
-        const values2 = other.get(key)
-        for (const [val1, mul1] of values1) {
-          for (const [val2, mul2] of values2) {
+        const otherValues = other.get(key)
+        for (const [val1, mul1] of valueMap.values()) {
+          for (const [val2, mul2] of otherValues) {
             if (mul1 !== 0 && mul2 !== 0) {
               result.push([[key, [val1, val2]], mul1 * mul2])
             }
@@ -128,11 +102,11 @@ export class Index<K, V> {
         }
       }
     } else {
-      for (const [key, values2] of other.entries()) {
+      for (const [key, otherValueMap] of other.entries()) {
         if (!this.has(key)) continue
-        const values1 = this.get(key)
-        for (const [val2, mul2] of values2) {
-          for (const [val1, mul1] of values1) {
+        const values = this.get(key)
+        for (const [val2, mul2] of otherValueMap.values()) {
+          for (const [val1, mul1] of values) {
             if (mul1 !== 0 && mul2 !== 0) {
               result.push([[key, [val1, val2]], mul1 * mul2])
             }

--- a/packages/d2mini/src/operators/join.ts
+++ b/packages/d2mini/src/operators/join.ts
@@ -77,13 +77,6 @@ export class JoinOperator<K, V1, V2> extends BinaryOperator<
 
     // Append deltaB to indexB
     this.#indexB.append(deltaB)
-
-    // Compact both indexes to consolidate values and remove zero-multiplicity entries
-    // Only compact changed keys for efficiency
-    deltaA.compact()
-    deltaB.compact()
-    this.#indexA.compact()
-    this.#indexB.compact()
   }
 }
 

--- a/packages/d2mini/src/operators/reduce copy.ts
+++ b/packages/d2mini/src/operators/reduce copy.ts
@@ -28,8 +28,9 @@ export class ReduceOperator<K, V1, V2> extends UnaryOperator<[K, V1], [K, V2]> {
   }
 
   run(): void {
-    // Collect all input messages and update the index
     const keysTodo = new Set<K>()
+
+    // Collect all input messages and update the index
     for (const message of this.inputMessages()) {
       for (const [item, multiplicity] of message.getInner()) {
         const [key, value] = item
@@ -45,55 +46,26 @@ export class ReduceOperator<K, V1, V2> extends UnaryOperator<[K, V1], [K, V2]> {
       const currOut = this.#indexOut.get(key)
       const out = this.#f(curr)
 
-      // Create maps for current and previous outputs
-      const newOutputMap = new Map<
-        string,
-        { value: V2; multiplicity: number }
-      >()
-      const oldOutputMap = new Map<
-        string,
-        { value: V2; multiplicity: number }
-      >()
-
-      // Process new output
+      // Calculate delta between current and previous output
+      const delta = new Map<string, number>()
+      const values = new Map<string, V2>()
       for (const [value, multiplicity] of out) {
         const valueKey = hash(value)
-        if (newOutputMap.has(valueKey)) {
-          newOutputMap.get(valueKey)!.multiplicity += multiplicity
-        } else {
-          newOutputMap.set(valueKey, { value, multiplicity })
-        }
+        values.set(valueKey, value)
+        delta.set(valueKey, (delta.get(valueKey) || 0) + multiplicity)
       }
-
-      // Process previous output
       for (const [value, multiplicity] of currOut) {
         const valueKey = hash(value)
-        if (oldOutputMap.has(valueKey)) {
-          oldOutputMap.get(valueKey)!.multiplicity += multiplicity
-        } else {
-          oldOutputMap.set(valueKey, { value, multiplicity })
-        }
+        values.set(valueKey, value)
+        delta.set(valueKey, (delta.get(valueKey) || 0) - multiplicity)
       }
 
-      // First, emit removals for old values that are no longer present or have changed
-      for (const [valueKey, { value, multiplicity }] of oldOutputMap) {
-        const newEntry = newOutputMap.get(valueKey)
-        if (!newEntry || newEntry.multiplicity !== multiplicity) {
-          // Remove the old value entirely
-          result.push([[key, value], -multiplicity])
-          this.#indexOut.addValue(key, [value, -multiplicity])
-        }
-      }
-
-      // Then, emit additions for new values that are not present in old or have changed
-      for (const [valueKey, { value, multiplicity }] of newOutputMap) {
-        const oldEntry = oldOutputMap.get(valueKey)
-        if (!oldEntry || oldEntry.multiplicity !== multiplicity) {
-          // Add the new value only if it has non-zero multiplicity
-          if (multiplicity !== 0) {
-            result.push([[key, value], multiplicity])
-            this.#indexOut.addValue(key, [value, multiplicity])
-          }
+      // Add non-zero deltas to result
+      for (const [valueKey, multiplicity] of delta) {
+        const value = values.get(valueKey)!
+        if (multiplicity !== 0) {
+          result.push([[key, value], multiplicity])
+          this.#indexOut.addValue(key, [value, multiplicity])
         }
       }
     }

--- a/packages/d2mini/src/operators/reduce.ts
+++ b/packages/d2mini/src/operators/reduce.ts
@@ -75,6 +75,15 @@ export class ReduceOperator<K, V1, V2> extends UnaryOperator<[K, V1], [K, V2]> {
         }
       }
 
+      // NOTE: in the below logic if an element is still present
+      //       but its multiplicity changed then we are going
+      //       to emit 2 diffs: a -oldMultiplicity and a +newMultiplicity
+      //       Why not detect this case and emit a single diff newMultiplicity - oldMultiplicity ?
+      //
+      //       We could when we map of both maps we could detect that it is in both (i.e. add an else branch)
+      //       and keep track of a set of keys that are in both
+      //       then a third for loop that loops over those common keys and emits the diff in multiplicity
+
       // First, emit removals for old values that are no longer present or have changed
       for (const [valueKey, { value, multiplicity }] of oldOutputMap) {
         const newEntry = newOutputMap.get(valueKey)
@@ -101,11 +110,6 @@ export class ReduceOperator<K, V1, V2> extends UnaryOperator<[K, V1], [K, V2]> {
     if (result.length > 0) {
       this.output.sendData(new MultiSet(result))
     }
-
-    // Compact both indexes to consolidate values and remove zero-multiplicity entries
-    // Only compact changed keys for efficiency
-    this.#index.compact()
-    this.#indexOut.compact()
   }
 }
 

--- a/packages/d2mini/src/operators/topKWithFractionalIndex.ts
+++ b/packages/d2mini/src/operators/topKWithFractionalIndex.ts
@@ -293,11 +293,6 @@ export class TopKWithFractionalIndexOperator<K, V1> extends UnaryOperator<
     if (result.length > 0) {
       this.output.sendData(new MultiSet(result))
     }
-
-    // Compact both indexes to consolidate values and remove zero-multiplicity entries
-    // Only compact changed keys for efficiency
-    this.#index.compact()
-    this.#indexOut.compact()
   }
 }
 

--- a/packages/d2mini/tests/indexes.test.ts
+++ b/packages/d2mini/tests/indexes.test.ts
@@ -31,17 +31,9 @@ describe('Index', () => {
       index.addValue('key1', [10, 1])
       index.addValue('key1', [10, -1])
 
-      // Before compaction, values are stored as-is
+      // Value is compacted on the fly
       const result = index.get('key1')
-      expect(result).toEqual([
-        [10, 1],
-        [10, -1],
-      ])
-
-      // After compaction, zero-multiplicity values are removed
-      index.compact(['key1'])
-      const compactedResult = index.get('key1')
-      expect(compactedResult).toEqual([])
+      expect(result).toEqual([])
     })
   })
 
@@ -70,14 +62,6 @@ describe('Index', () => {
 
       index.append(other)
 
-      // Before compaction, values are stored separately
-      expect(index.get('key1')).toEqual([
-        [10, 2],
-        [10, 3],
-      ])
-
-      // After compaction, multiplicities are combined
-      index.compact(['key1'])
       expect(index.get('key1')).toEqual([[10, 5]])
     })
   })
@@ -164,42 +148,16 @@ describe('Index', () => {
     // Append should also track changed keys
     index.append(other)
 
-    // Before compaction, all values should be stored as-is
-    expect(index.get('key1')).toEqual([
-      [10, 1],
-      [10, -1],
-    ])
-    expect(index.get('key2')).toEqual([[20, 1]])
-    expect(index.get('key3')).toEqual([[30, 1]])
-    expect(index.get('key4')).toEqual([
-      [40, 1],
-      [40, -1],
-    ])
-    expect(index.get('key5')).toEqual([[50, 1]])
-
-    // Compact without arguments should only compact changed keys
-    index.compact()
-
-    // After compaction, values should be consolidated and zero-multiplicity entries removed
+    // Values should be consolidated and zero-multiplicity entries removed
     expect(index.get('key1')).toEqual([]) // Cancelled out
     expect(index.get('key2')).toEqual([[20, 1]])
     expect(index.get('key3')).toEqual([[30, 1]])
     expect(index.get('key4')).toEqual([]) // Cancelled out
     expect(index.get('key5')).toEqual([[50, 1]])
 
-    // Add more values after compaction
+    // Add more values
     index.addValue('key2', [25, 1])
     index.addValue('key6', [60, 1])
-
-    // Only key2 and key6 should have new uncompacted values
-    expect(index.get('key2')).toEqual([
-      [20, 1],
-      [25, 1],
-    ])
-    expect(index.get('key6')).toEqual([[60, 1]])
-
-    // Compact again - should only affect key2 and key6
-    index.compact()
 
     expect(index.get('key2')).toEqual([
       [20, 1],


### PR DESCRIPTION
This PR reverts the changes to the index from https://github.com/electric-sql/d2ts/pull/69
This means we are keeping the consolidated multiplicity instead of an array of multiplicities that needs to be consolidated at compaction time. By keeping a map of consolidated values it is cheaper to get a value's multiplicity, which is important for the efficient topK operator from https://github.com/electric-sql/d2ts/pull/72