### PR TITLE
fix: global_last_seen_lsn is a string

### DIFF
--- a/examples/electric/docker-compose.yml
+++ b/examples/electric/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     image: electricsql/electric:latest
     environment:
       DATABASE_URL: postgresql://postgres:password@postgres:5432/electric?sslmode=disable
+      ELECTRIC_INSECURE: true
     ports:
       - 3000:3000
     depends_on:

--- a/packages/d2ts/src/electric/index.ts
+++ b/packages/d2ts/src/electric/index.ts
@@ -148,11 +148,11 @@ export function electricStreamToD2Input<T extends Row<unknown> = Row>({
           if (changes.length > 0) {
             sendChanges(lastLsn)
           }
-          if (typeof message.headers.global_last_seen_lsn !== `number`) {
-            throw new Error(`global_last_seen_lsn is not a number`)
+          if (typeof message.headers.global_last_seen_lsn !== `string`) {
+            throw new Error(`global_last_seen_lsn not in message headers`)
           }
           const lsn = message.headers.global_last_seen_lsn
-          sendFrontier(lsn)
+          sendFrontier(parseInt(lsn))
           if (runOn === 'up-to-date' || runOn === 'lsn-advance') {
             log?.('running graph on up-to-date')
             graph.run()


### PR DESCRIPTION
In the `d2ts` package, there is an error in the `electricStreamToD2Input` where the function assumes/requires `global_last_seen_lsn` to be a `number`, but it is a `string`.

Without this fix, the `d2ts` pipeline crashes and doesn't properly connect and read data from the stream.

